### PR TITLE
File mode must be a string

### DIFF
--- a/manifests/byport.pp
+++ b/manifests/byport.pp
@@ -27,7 +27,7 @@ define authbind::byport (
     file {"/etc/authbind/byport/${port}":
         ensure     => file,
         require    => Package['authbind'],
-        mode       => 755,
+        mode       => '755',
         owner      => $uid,
     }
 }


### PR DESCRIPTION
```
error during compilation: Parameter mode failed on File[/etc/authbind/byport/443]: The file mode specification must be a string, not 'Fixnum' at /Users/carlos/Code/puppet/modules/my_app/spec/fixtures/modules/authbind/manifests/byport.pp:27
```
